### PR TITLE
[notready] Allow an explicit minzoom/maxzoom to be set in config to limit zoom rage

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,5 +276,8 @@ function zoomBySpeed (config, step) {
   var zoomDiff = speedDiff / 70;
   // Determine new zoom level
   var response = config.zoom - zoomDiff;
-  return response;
+
+  var minzoom = config.minzoom || (config.zoom-1);
+  var maxzoom = config.maxzoom || (config.zoom+1);
+  return Math.min(maxzoom, Math.max(minzoom, response));
 }


### PR DESCRIPTION
For some more control over how far out/in we'll zoom no matter how fast you're going :sweat_smile: 
- [ ] validation
- [ ] tests
- [ ] docs

cc @emilymdubois
